### PR TITLE
Some preparation for updated Math Interface merge

### DIFF
--- a/mr/HH.hpp
+++ b/mr/HH.hpp
@@ -1,4 +1,4 @@
-//
+////
 // MR - 2-loop matching and 3-loop Running, including full 2-loop EW corrections
 // Copyright (C) 2014 Andrey Pikelner <pikelner@theor.jinr.ru>
 //
@@ -28,12 +28,12 @@
 #include "base.hpp"
 
 template<class T>
-class HH : public PoleMass
+class HH 
 {
 };
 
 template<>
-class HH<OS> : public PoleMass
+class HH<OS> : public PoleMassAndCouplings
 {
 
   long double MMb, MMt, MMH, MMW, MMZ, mu2;
@@ -125,7 +125,7 @@ public:
 
 
 template<>
-class HH<MS>
+class HH<MS> : public PoleMass
 {
 
   long double mmb, mmt, mmH, mmW, mmZ, mu2;
@@ -167,7 +167,7 @@ public:
   
   void init();
 
-  long double x01(size_t nL = 2, size_t nH = 1, size_t boson = 1);
+//  long double x01(size_t nL = 2, size_t nH = 1, size_t boson = 1);
 
   
   long double x10(size_t nL = 2, size_t nH = 1, size_t boson = 1);

--- a/mr/Makefile.am
+++ b/mr/Makefile.am
@@ -50,11 +50,13 @@ ZZMS2OS = mZZos10.cpp mZZos11.cpp mZZos20.cpp
 HHMS2OS = mHHos10.cpp mHHos11.cpp mHHos20.cpp
 # t pole mass from MS input
 TTMS2OS = mttos01.cpp mttos10.cpp mttos11.cpp mttos20.cpp
+# b pole mass from MS input
+BBMS2OS = mbbos01.cpp mbbos10.cpp mbbos11.cpp mbbos20.cpp
 
 
 libmr_a_SOURCES =    $(MAINSRC) $(MAINHPP) $(ALPHAGF) $(RUNSRC) $(BBMS) $(WWMS) $(ZZMS) $(HHMS) $(TTMS)\
  $(HHMSGL) $(BBMSGL) $(TTMSGL) $(DRMSOS) $(DRMSMS)\
- $(WWMS2OS) $(ZZMS2OS) $(HHMS2OS) $(TTMS2OS)
+ $(WWMS2OS) $(ZZMS2OS) $(HHMS2OS) $(TTMS2OS) $(BBMS2OS)
 
 libmr_a_CPPFLAGS = $(MR_CFLAGS) -I$(top_srcdir) -I$(top_srcdir)/tsil-1.21 -I$(top_srcdir)/Eigen
 

--- a/mr/WW.hpp
+++ b/mr/WW.hpp
@@ -30,13 +30,12 @@
 
 template<class T>
 class WW 
-//: public PoleMass
 {
 };
 
 
 template<>
-class WW<OS> : public PoleMass
+class WW<OS> : public PoleMassAndCouplings
 {
 
   long double MMb, MMt, MMH, MMW, MMZ, mu2;
@@ -104,7 +103,7 @@ public:
 
 
 template<>
-class WW<MS>
+class WW<MS> : public PoleMass
 {
 
   long double mmb, mmt, mmH, mmW, mmZ, mu2;

--- a/mr/ZZ.hpp
+++ b/mr/ZZ.hpp
@@ -28,12 +28,12 @@
 #include "base.hpp"
 
 template<class T>
-class ZZ : public PoleMass
+class ZZ 
 {
 };
 
 template<>
-class ZZ<OS> : public PoleMass
+class ZZ<OS> : public PoleMassAndCouplings
 {
 
   long double MMb, MMt, MMH, MMW, MMZ, mu2;
@@ -91,7 +91,7 @@ public:
 };
 
 template<>
-class ZZ<MS>
+class ZZ<MS> : public PoleMass
 {
 
   long double mmb, mmt, mmH, mmW, mmZ, mu2;

--- a/mr/base.hpp
+++ b/mr/base.hpp
@@ -36,12 +36,13 @@ class PoleMass
   // Mass corrections
   // 
 public:
+
   virtual long double x10(size_t nL = 2, size_t nH = 1, size_t boson = 1) = 0;
   
   virtual long double x11(size_t nL = 2, size_t nH = 1, size_t boson = 1) = 0;
-  
+
   virtual long double x20(size_t nL = 2, size_t nH = 1, size_t boson = 1) = 0;
-  
+
   virtual long double x01(size_t nL = 2, size_t nH = 1, size_t boson = 1)
   {
     std::cout << "Order a^0*as^1 is not implemented for this particle" << std::endl;
@@ -57,7 +58,12 @@ public:
     std::cout << "Order a^0*as^3 is not implemented for this particle" << std::endl;
     return 0;
   }
-  
+  virtual long double x04(size_t nL = 2, size_t nH = 1, size_t boson = 1)
+  {
+    std::cout << "Order a^0*as^4 is not implemented for this particle" << std::endl;
+    return 0;
+  }
+
   // and meta method
   long double x(size_t apow, size_t aspow, size_t nL = 2, size_t nH = 1, size_t boson = 1)
   {
@@ -73,6 +79,8 @@ public:
       return x02(nL, nH, boson);
     if(apow == 0 && aspow == 3)
       return x03(nL, nH, boson);
+    if(apow == 0 && aspow == 4)
+      return x04(nL, nH, boson);
     return 0;
   }
   // Gaugeless limit
@@ -91,6 +99,22 @@ public:
   // 
   // virtual std::complex<long double> my01() = 0;
 
+
+  // Gaugeless limit
+  // virtual std::complex<long double> mygl01();
+
+  // virtual std::complex<long double> mygl10(size_t nL = 2, size_t nH = 1);
+
+  // virtual std::complex<long double> mygl11(size_t nL = 2, size_t nH = 1);
+
+  // virtual std::complex<long double> mygl20(size_t nL = 2, size_t nH = 1);
+
+
+};
+
+class PoleMassAndCouplings : public PoleMass
+{
+public:
   virtual long double y10(size_t nL = 2, size_t nH = 1, size_t boson = 1) = 0;
 
   virtual long double y11(size_t nL = 2, size_t nH = 1, size_t boson = 1) = 0;
@@ -111,17 +135,10 @@ public:
       return x02(nL, nH, boson);
     if(apow == 0 && aspow == 3)
       return x03(nL, nH, boson);
+    if(apow == 0 && aspow == 4)
+      return x04(nL, nH, boson);
     return 0;
   }
-
-  // Gaugeless limit
-  // virtual std::complex<long double> mygl01();
-
-  // virtual std::complex<long double> mygl10(size_t nL = 2, size_t nH = 1);
-
-  // virtual std::complex<long double> mygl11(size_t nL = 2, size_t nH = 1);
-
-  // virtual std::complex<long double> mygl20(size_t nL = 2, size_t nH = 1);
 
 
 };

--- a/mr/bb.hpp
+++ b/mr/bb.hpp
@@ -109,11 +109,11 @@ public:
 
   long double ygl20(size_t nL = 2, size_t nH = 1, size_t boson = 1);
 
-
   std::complex<long double> det(const long double & a, const long double & b, const long double & c)
   {
     return 1./(a*a + b*b + c*c - 2*a*b - 2*b*c - 2*c*a);
   }
+
   
 };
 
@@ -158,6 +158,10 @@ public:
 
   long double x20(size_t nL = 2, size_t nH = 1, size_t boson = 1);
   
+  std::complex<long double> det(const long double & a, const long double & b, const long double & c)
+  {
+    return 1./(a*a + b*b + c*c - 2*a*b - 2*b*c - 2*c*a);
+  }
 };
 
 

--- a/mr/bb.hpp
+++ b/mr/bb.hpp
@@ -33,7 +33,7 @@ class bb
 };
 
 template<>
-class bb<OS> : public PoleMass
+class bb<OS> : public PoleMassAndCouplings
 {
 
   long double MMb, MMt, MMH, MMW, MMZ, mu2;
@@ -119,7 +119,7 @@ public:
 
 
 template<>
-class bb<MS> 
+class bb<MS> : public PoleMass
 {
 
   long double mmb,mmt, mmH, mmW, mmZ, mu2;

--- a/mr/sminput.hpp
+++ b/mr/sminput.hpp
@@ -175,6 +175,27 @@ public:
     imb(mb_), imW(mW_), imZ(mZ_), imH(mH_), imt(mt_), iv(v_), scale(scale_)
   {
   }
+  bool operator < (const MSinput& b) const 
+  {
+    if(imb < b.mb()) return true;
+    else if(imb > b.mb()) return false;
+    else
+      
+      if(imW < b.mW()) return true;
+      else if(imW > b.mW()) return false;
+      else
+        
+        if(imZ < b.mZ()) return true;
+        else if(imZ > b.mZ()) return false;
+        else
+        
+          if(imH < b.mH()) return true;
+          else if(imH > b.mH()) return false;
+          else
+            if(imt < b.mt()) return true;
+            else if(imt > b.mt()) return false;
+    return false;
+  }
 
   // Factory
   static MSinput fromMasses(long double mb, long double mW, long double mZ, long double mH, long double mt)

--- a/mr/tt.hpp
+++ b/mr/tt.hpp
@@ -28,12 +28,12 @@
 #include "base.hpp"
 
 template<class T>
-class tt
+class tt 
 {
 };
 
 template<>
-class tt<OS> : public PoleMass
+class tt<OS> : public PoleMassAndCouplings
 {
   
   long double MMb,MMt, MMH, MMW, MMZ, mu2;
@@ -149,7 +149,7 @@ tt()
 
 
 template<>
-class tt<MS> 
+class tt<MS> : public PoleMass
 {
 
 long double mmb,mmt, mmH, mmW, mmZ, mu2;


### PR DESCRIPTION
Base class PoleMass is splitted (again).
- PoleMass defines only x(i,j) and is used only in <MS> type classes, which store corrections to M/m relations (added x04);
-  PoleMassAndCouplings defines y(i,j) and is used only for <OS> type classes, which store corrections corrections for m/M relations and corresponding couplings
- operator "<" definition returned back to MSInput . Why deleting?
